### PR TITLE
Fixing link to meetup.com

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
     <header>
       <h1><a href="/">₿uilder</a></h1>
       <nav>
-        <a href="https://www.meetup.com/bay-area-bitcoiners/events/308542831" target="_blank">Meetup</a>
+        <a href="https://www.meetup.com/bay-area-bitcoiners" target="_blank">Meetup</a>
         <a href="https://twitter.com/bbuildersf" target="_blank">Twitter</a>
         <a href="https://github.com/BitcoinBuilderSF/BitcoinBuilderSF" target="_blank">GitHub</a>
         <a href="/feed.xml">RSS</a>


### PR DESCRIPTION
The link points to an old event. 
Not it points to the general Bay Area Bitcoins Meetup page