### PR TITLE
fix: update deprecated Zola markdown config field

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,6 @@ generate_feeds = true
 feed_filenames = ["feed.xml"]
 
 [markdown]
-highlight_code = false
+highlighting = false
 
 [extra]


### PR DESCRIPTION
Rename `highlight_code` to `highlighting` to fix TOML parse error in newer Zola versions.

Fixes the CI from failing https://github.com/BitcoinBuilderSF/BitcoinBuilderSF/actions/runs/21502177964/job/61950619406